### PR TITLE
Support destructuring assignment with private named fields

### DIFF
--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -1676,6 +1676,10 @@ namespace ts {
         name: Identifier | PrivateName;
     }
 
+    export interface PrivateNamedPropertyAccessExpression extends PropertyAccessExpression {
+        name: PrivateName;
+    }
+
     export interface SuperPropertyAccessExpression extends PropertyAccessExpression {
         expression: SuperExpression;
     }

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -6095,6 +6095,10 @@ namespace ts {
         return node && isPropertyDeclaration(node) && isPrivateName(node.name);
     }
 
+    export function isPrivateNamedPropertyAccessExpression(node: Node): node is PrivateNamedPropertyAccessExpression {
+        return node && isPropertyAccessExpression(node) && isPrivateName(node.name);
+    }
+
     // Type members
 
     export function isTypeElement(node: Node): node is TypeElement {

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -1056,6 +1056,9 @@ declare namespace ts {
         expression: LeftHandSideExpression;
         name: Identifier | PrivateName;
     }
+    interface PrivateNamedPropertyAccessExpression extends PropertyAccessExpression {
+        name: PrivateName;
+    }
     interface SuperPropertyAccessExpression extends PropertyAccessExpression {
         expression: SuperExpression;
     }
@@ -3462,6 +3465,7 @@ declare namespace ts {
     function isClassLike(node: Node): node is ClassLikeDeclaration;
     function isAccessor(node: Node): node is AccessorDeclaration;
     function isPrivateNamedPropertyDeclaration(node: Node): node is PrivateNamedPropertyDeclaration;
+    function isPrivateNamedPropertyAccessExpression(node: Node): node is PrivateNamedPropertyAccessExpression;
     function isTypeElement(node: Node): node is TypeElement;
     function isClassOrTypeElement(node: Node): node is ClassElement | TypeElement;
     function isObjectLiteralElementLike(node: Node): node is ObjectLiteralElementLike;

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -1056,6 +1056,9 @@ declare namespace ts {
         expression: LeftHandSideExpression;
         name: Identifier | PrivateName;
     }
+    interface PrivateNamedPropertyAccessExpression extends PropertyAccessExpression {
+        name: PrivateName;
+    }
     interface SuperPropertyAccessExpression extends PropertyAccessExpression {
         expression: SuperExpression;
     }
@@ -3462,6 +3465,7 @@ declare namespace ts {
     function isClassLike(node: Node): node is ClassLikeDeclaration;
     function isAccessor(node: Node): node is AccessorDeclaration;
     function isPrivateNamedPropertyDeclaration(node: Node): node is PrivateNamedPropertyDeclaration;
+    function isPrivateNamedPropertyAccessExpression(node: Node): node is PrivateNamedPropertyAccessExpression;
     function isTypeElement(node: Node): node is TypeElement;
     function isClassOrTypeElement(node: Node): node is ClassElement | TypeElement;
     function isObjectLiteralElementLike(node: Node): node is ObjectLiteralElementLike;

--- a/tests/baselines/reference/privateNameDestructuringAssignment.js
+++ b/tests/baselines/reference/privateNameDestructuringAssignment.js
@@ -1,0 +1,26 @@
+//// [privateNameDestructuringAssignment.ts]
+class Test {
+    #myPropDefault = 23;
+    #myProp: number;
+    constructor() {
+        ({ value: this.#myProp } = { value: 10 });
+        ({ something: this.#myProp } = { something: this.#myPropDefault });
+    }
+}
+
+
+//// [privateNameDestructuringAssignment.js]
+var _classPrivateFieldSet = function (receiver, privateMap, value) { if (!privateMap.has(receiver)) { throw new TypeError("attempted to set private field on non-instance"); } privateMap.set(receiver, value); return value; };
+var _classPrivateFieldGet = function (receiver, privateMap) { if (!privateMap.has(receiver)) { throw new TypeError("attempted to get private field on non-instance"); } return privateMap.get(receiver); };
+var Test = /** @class */ (function () {
+    function Test() {
+        _myPropDefault.set(this, void 0);
+        _myProp.set(this, void 0);
+        _classPrivateFieldSet(this, _myPropDefault, 23);
+        ({ set value(x) { return _classPrivateFieldSet(this, _myProp, x); } }.value = { value: 10 }.value);
+        ({ set value(x) { return _classPrivateFieldSet(this, _myProp, x); } }.value = { something: _classPrivateFieldGet(this, _myPropDefault) }.something);
+    }
+    return Test;
+}());
+var _myPropDefault = new WeakMap;
+var _myProp = new WeakMap;

--- a/tests/baselines/reference/privateNameDestructuringAssignment.symbols
+++ b/tests/baselines/reference/privateNameDestructuringAssignment.symbols
@@ -1,0 +1,27 @@
+=== tests/cases/conformance/classes/members/privateNames/privateNameDestructuringAssignment.ts ===
+class Test {
+>Test : Symbol(Test, Decl(privateNameDestructuringAssignment.ts, 0, 0))
+
+    #myPropDefault = 23;
+>#myPropDefault : Symbol(Test[#myPropDefault], Decl(privateNameDestructuringAssignment.ts, 0, 12))
+
+    #myProp: number;
+>#myProp : Symbol(Test[#myProp], Decl(privateNameDestructuringAssignment.ts, 1, 24))
+
+    constructor() {
+        ({ value: this.#myProp } = { value: 10 });
+>value : Symbol(value, Decl(privateNameDestructuringAssignment.ts, 4, 10))
+>this.#myProp : Symbol(Test[#myProp], Decl(privateNameDestructuringAssignment.ts, 1, 24))
+>this : Symbol(Test, Decl(privateNameDestructuringAssignment.ts, 0, 0))
+>value : Symbol(value, Decl(privateNameDestructuringAssignment.ts, 4, 36))
+
+        ({ something: this.#myProp } = { something: this.#myPropDefault });
+>something : Symbol(something, Decl(privateNameDestructuringAssignment.ts, 5, 10))
+>this.#myProp : Symbol(Test[#myProp], Decl(privateNameDestructuringAssignment.ts, 1, 24))
+>this : Symbol(Test, Decl(privateNameDestructuringAssignment.ts, 0, 0))
+>something : Symbol(something, Decl(privateNameDestructuringAssignment.ts, 5, 40))
+>this.#myPropDefault : Symbol(Test[#myPropDefault], Decl(privateNameDestructuringAssignment.ts, 0, 12))
+>this : Symbol(Test, Decl(privateNameDestructuringAssignment.ts, 0, 0))
+    }
+}
+

--- a/tests/baselines/reference/privateNameDestructuringAssignment.types
+++ b/tests/baselines/reference/privateNameDestructuringAssignment.types
@@ -1,0 +1,37 @@
+=== tests/cases/conformance/classes/members/privateNames/privateNameDestructuringAssignment.ts ===
+class Test {
+>Test : Test
+
+    #myPropDefault = 23;
+>#myPropDefault : number
+>23 : 23
+
+    #myProp: number;
+>#myProp : number
+
+    constructor() {
+        ({ value: this.#myProp } = { value: 10 });
+>({ value: this.#myProp } = { value: 10 }) : { value: number; }
+>{ value: this.#myProp } = { value: 10 } : { value: number; }
+>{ value: this.#myProp } : { value: number; }
+>value : number
+>this.#myProp : number
+>this : this
+>{ value: 10 } : { value: number; }
+>value : number
+>10 : 10
+
+        ({ something: this.#myProp } = { something: this.#myPropDefault });
+>({ something: this.#myProp } = { something: this.#myPropDefault }) : { something: number; }
+>{ something: this.#myProp } = { something: this.#myPropDefault } : { something: number; }
+>{ something: this.#myProp } : { something: number; }
+>something : number
+>this.#myProp : number
+>this : this
+>{ something: this.#myPropDefault } : { something: number; }
+>something : number
+>this.#myPropDefault : number
+>this : this
+    }
+}
+

--- a/tests/cases/conformance/classes/members/privateNames/privateNameDestructuringAssignment.ts
+++ b/tests/cases/conformance/classes/members/privateNames/privateNameDestructuringAssignment.ts
@@ -1,0 +1,8 @@
+class Test {
+    #myPropDefault = 23;
+    #myProp: number;
+    constructor() {
+        ({ value: this.#myProp } = { value: 10 });
+        ({ something: this.#myProp } = { something: this.#myPropDefault });
+    }
+}


### PR DESCRIPTION
# Description of Changes
- Transformation of destructuring assignment which mutates private named fields.

# Steps to Test
- Build the compiler (`npm run build:compiler`)
- Run tests (`npm test`).
- Check compiler output of any example programs using destructuring assignment with ES private properties.