### PR TITLE
Baseline changes for ESNext Class Property Transformation

### DIFF
--- a/tests/baselines/reference/classBlockScoping.js
+++ b/tests/baselines/reference/classBlockScoping.js
@@ -34,8 +34,8 @@ function f(b: boolean) {
 }
 
 //// [classBlockScoping.js]
-var _a;
 function f(b) {
+    var _a;
     var Foo;
     if (b) {
         Foo = (_a = /** @class */ (function () {

--- a/tests/baselines/reference/classBlockScoping.js
+++ b/tests/baselines/reference/classBlockScoping.js
@@ -34,8 +34,8 @@ function f(b: boolean) {
 }
 
 //// [classBlockScoping.js]
+var _a;
 function f(b) {
-    var _a;
     var Foo;
     if (b) {
         Foo = (_a = /** @class */ (function () {

--- a/tests/baselines/reference/declarationEmitPrivateSymbolCausesVarDeclarationEmit2.js
+++ b/tests/baselines/reference/declarationEmitPrivateSymbolCausesVarDeclarationEmit2.js
@@ -34,8 +34,8 @@ var C = /** @class */ (function () {
     }
     return C;
 }());
-_a = a_1.x;
 exports.C = C;
+_a = a_1.x;
 //// [c.js]
 "use strict";
 var __extends = (this && this.__extends) || (function () {
@@ -64,8 +64,8 @@ var D = /** @class */ (function (_super) {
     }
     return D;
 }(b_1.C));
-_a = a_1.x;
 exports.D = D;
+_a = a_1.x;
 
 
 //// [a.d.ts]

--- a/tests/baselines/reference/decoratorsOnComputedProperties.js
+++ b/tests/baselines/reference/decoratorsOnComputedProperties.js
@@ -196,7 +196,8 @@ var __decorate = (this && this.__decorate) || function (decorators, target, key,
     else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
     return c > 3 && r && Object.defineProperty(target, key, r), r;
 };
-var _a, _b, _c, _d, _e, _f, _g, _h, _j, _k, _l, _m, _o, _p, _q, _r, _s, _t, _u, _v, _w, _x, _y, _z, _0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, _21;
+var _a, _b, _c, _d;
+var _e, _f, _g, _h, _j, _k, _l, _m, _o, _p, _q, _r, _s, _t, _u, _v, _w, _x, _y, _z, _0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, _21;
 function x(o, k) { }
 let i = 0;
 function foo() { return ++i + ""; }
@@ -209,11 +210,11 @@ class A {
         this[Symbol.iterator] = null;
         this["property4"] = 2;
         this[Symbol.match] = null;
-        this[_b] = null;
-        this[_d] = null;
+        this[_f] = null;
+        this[_h] = null;
     }
 }
-foo(), _a = foo(), _b = foo(), _c = fieldNameB, _d = fieldNameC;
+foo(), _e = foo(), _f = foo(), _g = fieldNameB, _h = fieldNameC;
 __decorate([
     x
 ], A.prototype, "property", void 0);
@@ -228,42 +229,42 @@ __decorate([
 ], A.prototype, Symbol.iterator, void 0);
 __decorate([
     x
-], A.prototype, _a, void 0);
+], A.prototype, _e, void 0);
 __decorate([
     x
-], A.prototype, _b, void 0);
+], A.prototype, _f, void 0);
 __decorate([
     x
-], A.prototype, _c, void 0);
+], A.prototype, _g, void 0);
 __decorate([
     x
-], A.prototype, _d, void 0);
-void (_j = class B {
+], A.prototype, _h, void 0);
+void (_a = class B {
         constructor() {
             this["property2"] = 2;
             this[Symbol.iterator] = null;
             this["property4"] = 2;
             this[Symbol.match] = null;
-            this[_f] = null;
-            this[_h] = null;
+            this[_k] = null;
+            this[_m] = null;
         }
     },
     foo(),
-    _e = foo(),
-    _f = foo(),
-    _g = fieldNameB,
-    _h = fieldNameC,
-    _j);
+    _j = foo(),
+    _k = foo(),
+    _l = fieldNameB,
+    _m = fieldNameC,
+    _a);
 class C {
     constructor() {
         this["property2"] = 2;
         this[Symbol.iterator] = null;
         this["property4"] = 2;
         this[Symbol.match] = null;
-        this[_l] = null;
-        this[_o] = null;
+        this[_p] = null;
+        this[_r] = null;
     }
-    [(foo(), _k = foo(), _l = foo(), _m = fieldNameB, _o = fieldNameC, "some" + "method")]() { }
+    [(foo(), _o = foo(), _p = foo(), _q = fieldNameB, _r = fieldNameC, "some" + "method")]() { }
 }
 __decorate([
     x
@@ -279,26 +280,26 @@ __decorate([
 ], C.prototype, Symbol.iterator, void 0);
 __decorate([
     x
-], C.prototype, _k, void 0);
-__decorate([
-    x
-], C.prototype, _l, void 0);
-__decorate([
-    x
-], C.prototype, _m, void 0);
-__decorate([
-    x
 ], C.prototype, _o, void 0);
+__decorate([
+    x
+], C.prototype, _p, void 0);
+__decorate([
+    x
+], C.prototype, _q, void 0);
+__decorate([
+    x
+], C.prototype, _r, void 0);
 void class D {
     constructor() {
         this["property2"] = 2;
         this[Symbol.iterator] = null;
         this["property4"] = 2;
         this[Symbol.match] = null;
-        this[_q] = null;
-        this[_s] = null;
+        this[_t] = null;
+        this[_v] = null;
     }
-    [(foo(), _p = foo(), _q = foo(), _r = fieldNameB, _s = fieldNameC, "some" + "method")]() { }
+    [(foo(), _s = foo(), _t = foo(), _u = fieldNameB, _v = fieldNameC, "some" + "method")]() { }
 };
 class E {
     constructor() {
@@ -306,12 +307,12 @@ class E {
         this[Symbol.iterator] = null;
         this["property4"] = 2;
         this[Symbol.match] = null;
-        this[_u] = null;
-        this[_w] = null;
+        this[_x] = null;
+        this[_z] = null;
     }
-    [(foo(), _t = foo(), _u = foo(), "some" + "method")]() { }
+    [(foo(), _w = foo(), _x = foo(), "some" + "method")]() { }
 }
-_v = fieldNameB, _w = fieldNameC;
+_y = fieldNameB, _z = fieldNameC;
 __decorate([
     x
 ], E.prototype, "property", void 0);
@@ -326,43 +327,43 @@ __decorate([
 ], E.prototype, Symbol.iterator, void 0);
 __decorate([
     x
-], E.prototype, _t, void 0);
-__decorate([
-    x
-], E.prototype, _u, void 0);
-__decorate([
-    x
-], E.prototype, _v, void 0);
-__decorate([
-    x
 ], E.prototype, _w, void 0);
-void (_1 = class F {
+__decorate([
+    x
+], E.prototype, _x, void 0);
+__decorate([
+    x
+], E.prototype, _y, void 0);
+__decorate([
+    x
+], E.prototype, _z, void 0);
+void (_b = class F {
         constructor() {
             this["property2"] = 2;
             this[Symbol.iterator] = null;
             this["property4"] = 2;
             this[Symbol.match] = null;
-            this[_y] = null;
-            this[_0] = null;
+            this[_1] = null;
+            this[_3] = null;
         }
-        [(foo(), _x = foo(), _y = foo(), "some" + "method")]() { }
+        [(foo(), _0 = foo(), _1 = foo(), "some" + "method")]() { }
     },
-    _z = fieldNameB,
-    _0 = fieldNameC,
-    _1);
+    _2 = fieldNameB,
+    _3 = fieldNameC,
+    _b);
 class G {
     constructor() {
         this["property2"] = 2;
         this[Symbol.iterator] = null;
         this["property4"] = 2;
         this[Symbol.match] = null;
-        this[_3] = null;
         this[_5] = null;
+        this[_7] = null;
     }
-    [(foo(), _2 = foo(), _3 = foo(), "some" + "method")]() { }
-    [(_4 = fieldNameB, "some" + "method2")]() { }
+    [(foo(), _4 = foo(), _5 = foo(), "some" + "method")]() { }
+    [(_6 = fieldNameB, "some" + "method2")]() { }
 }
-_5 = fieldNameC;
+_7 = fieldNameC;
 __decorate([
     x
 ], G.prototype, "property", void 0);
@@ -377,43 +378,43 @@ __decorate([
 ], G.prototype, Symbol.iterator, void 0);
 __decorate([
     x
-], G.prototype, _2, void 0);
-__decorate([
-    x
-], G.prototype, _3, void 0);
-__decorate([
-    x
 ], G.prototype, _4, void 0);
 __decorate([
     x
 ], G.prototype, _5, void 0);
-void (_10 = class H {
+__decorate([
+    x
+], G.prototype, _6, void 0);
+__decorate([
+    x
+], G.prototype, _7, void 0);
+void (_c = class H {
         constructor() {
             this["property2"] = 2;
             this[Symbol.iterator] = null;
             this["property4"] = 2;
             this[Symbol.match] = null;
-            this[_7] = null;
             this[_9] = null;
+            this[_11] = null;
         }
-        [(foo(), _6 = foo(), _7 = foo(), "some" + "method")]() { }
-        [(_8 = fieldNameB, "some" + "method2")]() { }
+        [(foo(), _8 = foo(), _9 = foo(), "some" + "method")]() { }
+        [(_10 = fieldNameB, "some" + "method2")]() { }
     },
-    _9 = fieldNameC,
-    _10);
+    _11 = fieldNameC,
+    _c);
 class I {
     constructor() {
         this["property2"] = 2;
         this[Symbol.iterator] = null;
         this["property4"] = 2;
         this[Symbol.match] = null;
-        this[_12] = null;
-        this[_15] = null;
+        this[_13] = null;
+        this[_16] = null;
     }
-    [(foo(), _11 = foo(), _12 = foo(), _13 = "some" + "method")]() { }
-    [(_14 = fieldNameB, "some" + "method2")]() { }
+    [(foo(), _12 = foo(), _13 = foo(), _14 = "some" + "method")]() { }
+    [(_15 = fieldNameB, "some" + "method2")]() { }
 }
-_15 = fieldNameC;
+_16 = fieldNameC;
 __decorate([
     x
 ], I.prototype, "property", void 0);
@@ -428,30 +429,30 @@ __decorate([
 ], I.prototype, Symbol.iterator, void 0);
 __decorate([
     x
-], I.prototype, _11, void 0);
-__decorate([
-    x
 ], I.prototype, _12, void 0);
 __decorate([
     x
-], I.prototype, _13, null);
+], I.prototype, _13, void 0);
 __decorate([
     x
-], I.prototype, _14, void 0);
+], I.prototype, _14, null);
 __decorate([
     x
 ], I.prototype, _15, void 0);
-void (_21 = class J {
+__decorate([
+    x
+], I.prototype, _16, void 0);
+void (_d = class J {
         constructor() {
             this["property2"] = 2;
             this[Symbol.iterator] = null;
             this["property4"] = 2;
             this[Symbol.match] = null;
-            this[_17] = null;
-            this[_20] = null;
+            this[_18] = null;
+            this[_21] = null;
         }
-        [(foo(), _16 = foo(), _17 = foo(), _18 = "some" + "method")]() { }
-        [(_19 = fieldNameB, "some" + "method2")]() { }
+        [(foo(), _17 = foo(), _18 = foo(), _19 = "some" + "method")]() { }
+        [(_20 = fieldNameB, "some" + "method2")]() { }
     },
-    _20 = fieldNameC,
-    _21);
+    _21 = fieldNameC,
+    _d);

--- a/tests/baselines/reference/dynamicNamesErrors.js
+++ b/tests/baselines/reference/dynamicNamesErrors.js
@@ -73,9 +73,11 @@ const y = Symbol();
 const z = Symbol();
 const w = Symbol();
 class ClassMemberVisibility {
+    static [x];
     static [y]() { return 0; }
     static get [z]() { return 0; }
     static set [w](value) { }
+    [x];
     [y]() { return 0; }
     get [z]() { return 0; }
     set [w](value) { }

--- a/tests/baselines/reference/importCallExpression4ESNext.js
+++ b/tests/baselines/reference/importCallExpression4ESNext.js
@@ -35,9 +35,7 @@ export function foo() { return "foo"; }
 export function backup() { return "backup"; }
 //// [2.js]
 class C {
-    constructor() {
-        this.myModule = import("./0");
-    }
+    myModule = import("./0");
     method() {
         const loadAsync = import("./0");
         this.myModule.then(Zero => {

--- a/tests/baselines/reference/importCallExpressionAsyncESNext.js
+++ b/tests/baselines/reference/importCallExpressionAsyncESNext.js
@@ -43,13 +43,11 @@ export const obj = {
     }
 };
 export class cl2 {
-    constructor() {
-        this.p = {
-            m: async () => {
-                const req = await import('./test'); // FOUR
-            }
-        };
-    }
+    p = {
+        m: async () => {
+            const req = await import('./test'); // FOUR
+        }
+    };
 }
 export const l = async () => {
     const req = await import('./test'); // FIVE

--- a/tests/baselines/reference/importCallExpressionInAMD4.js
+++ b/tests/baselines/reference/importCallExpressionInAMD4.js
@@ -63,9 +63,7 @@ define(["require", "exports"], function (require, exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     class C {
-        constructor() {
-            this.myModule = new Promise((resolve_1, reject_1) => { require(["./0"], resolve_1, reject_1); });
-        }
+        myModule = new Promise((resolve_1, reject_1) => { require(["./0"], resolve_1, reject_1); });
         method() {
             const loadAsync = new Promise((resolve_2, reject_2) => { require(["./0"], resolve_2, reject_2); });
             this.myModule.then(Zero => {
@@ -78,9 +76,7 @@ define(["require", "exports"], function (require, exports) {
         }
     }
     class D {
-        constructor() {
-            this.myModule = new Promise((resolve_4, reject_4) => { require(["./0"], resolve_4, reject_4); });
-        }
+        myModule = new Promise((resolve_4, reject_4) => { require(["./0"], resolve_4, reject_4); });
         method() {
             const loadAsync = new Promise((resolve_5, reject_5) => { require(["./0"], resolve_5, reject_5); });
             this.myModule.then(Zero => {

--- a/tests/baselines/reference/importCallExpressionInCJS5.js
+++ b/tests/baselines/reference/importCallExpressionInCJS5.js
@@ -58,9 +58,7 @@ exports.backup = backup;
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 class C {
-    constructor() {
-        this.myModule = Promise.resolve().then(() => require("./0"));
-    }
+    myModule = Promise.resolve().then(() => require("./0"));
     method() {
         const loadAsync = Promise.resolve().then(() => require("./0"));
         this.myModule.then(Zero => {
@@ -73,9 +71,7 @@ class C {
     }
 }
 class D {
-    constructor() {
-        this.myModule = Promise.resolve().then(() => require("./0"));
-    }
+    myModule = Promise.resolve().then(() => require("./0"));
     method() {
         const loadAsync = Promise.resolve().then(() => require("./0"));
         this.myModule.then(Zero => {

--- a/tests/baselines/reference/importCallExpressionInSystem4.js
+++ b/tests/baselines/reference/importCallExpressionInSystem4.js
@@ -78,9 +78,7 @@ System.register([], function (exports_1, context_1) {
         setters: [],
         execute: function () {
             C = class C {
-                constructor() {
-                    this.myModule = context_1.import("./0");
-                }
+                myModule = context_1.import("./0");
                 method() {
                     const loadAsync = context_1.import("./0");
                     this.myModule.then(Zero => {
@@ -93,9 +91,7 @@ System.register([], function (exports_1, context_1) {
                 }
             };
             D = class D {
-                constructor() {
-                    this.myModule = context_1.import("./0");
-                }
+                myModule = context_1.import("./0");
                 method() {
                     const loadAsync = context_1.import("./0");
                     this.myModule.then(Zero => {

--- a/tests/baselines/reference/importCallExpressionInUMD4.js
+++ b/tests/baselines/reference/importCallExpressionInUMD4.js
@@ -88,9 +88,7 @@ export class D {
     var __syncRequire = typeof module === "object" && typeof module.exports === "object";
     Object.defineProperty(exports, "__esModule", { value: true });
     class C {
-        constructor() {
-            this.myModule = __syncRequire ? Promise.resolve().then(() => require("./0")) : new Promise((resolve_1, reject_1) => { require(["./0"], resolve_1, reject_1); });
-        }
+        myModule = __syncRequire ? Promise.resolve().then(() => require("./0")) : new Promise((resolve_1, reject_1) => { require(["./0"], resolve_1, reject_1); });
         method() {
             const loadAsync = __syncRequire ? Promise.resolve().then(() => require("./0")) : new Promise((resolve_2, reject_2) => { require(["./0"], resolve_2, reject_2); });
             this.myModule.then(Zero => {
@@ -103,9 +101,7 @@ export class D {
         }
     }
     class D {
-        constructor() {
-            this.myModule = __syncRequire ? Promise.resolve().then(() => require("./0")) : new Promise((resolve_4, reject_4) => { require(["./0"], resolve_4, reject_4); });
-        }
+        myModule = __syncRequire ? Promise.resolve().then(() => require("./0")) : new Promise((resolve_4, reject_4) => { require(["./0"], resolve_4, reject_4); });
         method() {
             const loadAsync = __syncRequire ? Promise.resolve().then(() => require("./0")) : new Promise((resolve_5, reject_5) => { require(["./0"], resolve_5, reject_5); });
             this.myModule.then(Zero => {

--- a/tests/baselines/reference/potentiallyUncalledDecorators.js
+++ b/tests/baselines/reference/potentiallyUncalledDecorators.js
@@ -86,16 +86,20 @@ var __decorate = (this && this.__decorate) || function (decorators, target, key,
     return c > 3 && r && Object.defineProperty(target, key, r), r;
 };
 class FooComponent {
+    foo;
 }
 __decorate([
     Input
 ], FooComponent.prototype, "foo", void 0);
 class Person {
+    person;
+    any;
 }
 __decorate([
     tracked
 ], Person.prototype, "person", void 0);
 class MultiplyByTwo {
+    args;
     get multiplied() {
         return this.args.number * 2;
     }
@@ -104,6 +108,7 @@ __decorate([
     tracked('args')
 ], MultiplyByTwo.prototype, "multiplied", null);
 let A = class A {
+    foo;
     bar() { }
 };
 __decorate([
@@ -116,6 +121,7 @@ A = __decorate([
     noArgs
 ], A);
 let B = class B {
+    foo;
     bar() { }
 };
 __decorate([
@@ -128,6 +134,7 @@ B = __decorate([
     allRest
 ], B);
 let C = class C {
+    foo;
     bar() { }
 };
 __decorate([
@@ -140,6 +147,7 @@ C = __decorate([
     oneOptional
 ], C);
 let D = class D {
+    foo;
     bar() { }
 };
 __decorate([
@@ -152,6 +160,7 @@ D = __decorate([
     twoOptional
 ], D);
 let E = class E {
+    foo;
     bar() { }
 };
 __decorate([
@@ -164,6 +173,7 @@ E = __decorate([
     threeOptional
 ], E);
 let F = class F {
+    foo;
     bar() { }
 };
 __decorate([
@@ -176,6 +186,7 @@ F = __decorate([
     oneOptionalWithRest
 ], F);
 let G = class G {
+    foo;
     bar() { }
 };
 __decorate([

--- a/tests/baselines/reference/spreadMethods.js
+++ b/tests/baselines/reference/spreadMethods.js
@@ -43,9 +43,7 @@ sso.g; // ok
 
 //// [spreadMethods.js]
 class K {
-    constructor() {
-        this.p = 12;
-    }
+    p = 12;
     m() { }
     get g() { return 0; }
 }

--- a/tests/baselines/reference/systemModuleTargetES6.js
+++ b/tests/baselines/reference/systemModuleTargetES6.js
@@ -35,8 +35,8 @@ System.register([], function (exports_1, context_1) {
             MyClass2 = class MyClass2 {
                 static getInstance() { return MyClass2.value; }
             };
-            MyClass2.value = 42;
             exports_1("MyClass2", MyClass2);
+            MyClass2.value = 42;
         }
     };
 });

--- a/tests/baselines/reference/taggedTemplatesWithTypeArguments2.js
+++ b/tests/baselines/reference/taggedTemplatesWithTypeArguments2.js
@@ -53,6 +53,9 @@ const d = (new tag `${"hello"} ${"world"}`)(100, 200);
  */
 const e = new tag `hello`();
 class SomeBase {
+    a;
+    b;
+    c;
 }
 class SomeDerived extends SomeBase {
     constructor() {

--- a/tests/baselines/reference/transformApi/transformsCorrectly.rewrittenNamespaceFollowingClass.js
+++ b/tests/baselines/reference/transformApi/transformsCorrectly.rewrittenNamespaceFollowingClass.js
@@ -1,9 +1,7 @@
 class C {
-    constructor() {
-        this.foo = 10;
-    }
+    foo = 10;
+    static bar = 20;
 }
-C.bar = 20;
 (function (C) {
     C.x = 10;
 })(C || (C = {}));

--- a/tests/baselines/reference/uniqueSymbols.js
+++ b/tests/baselines/reference/uniqueSymbols.js
@@ -308,14 +308,13 @@ async function* asyncGenFuncYieldLetCall() { yield letCall; }
 async function* asyncGenFuncYieldVarCall() { yield varCall; }
 // classes
 class C {
-    constructor() {
-        this.readonlyCall = Symbol();
-        this.readwriteCall = Symbol();
-    }
+    static readonlyStaticCall = Symbol();
+    static readonlyStaticType;
+    static readonlyStaticTypeAndCall = Symbol();
+    static readwriteStaticCall = Symbol();
+    readonlyCall = Symbol();
+    readwriteCall = Symbol();
 }
-C.readonlyStaticCall = Symbol();
-C.readonlyStaticTypeAndCall = Symbol();
-C.readwriteStaticCall = Symbol();
 const constInitToCReadonlyStaticCall = C.readonlyStaticCall;
 const constInitToCReadonlyStaticType = C.readonlyStaticType;
 const constInitToCReadonlyStaticTypeAndCall = C.readonlyStaticTypeAndCall;
@@ -364,26 +363,24 @@ const o2 = {
 };
 // property initializers
 class C0 {
-    constructor() {
-        this.a = s;
-        this.b = N.s;
-        this.c = N["s"];
-        this.d = s;
-        this.e = N.s;
-        this.f = N["s"];
-    }
+    static a = s;
+    static b = N.s;
+    static c = N["s"];
+    static d = s;
+    static e = N.s;
+    static f = N["s"];
+    a = s;
+    b = N.s;
+    c = N["s"];
+    d = s;
+    e = N.s;
+    f = N["s"];
     method1() { return s; }
     async method2() { return s; }
     async *method3() { yield s; }
     *method4() { yield s; }
     method5(p = s) { return p; }
 }
-C0.a = s;
-C0.b = N.s;
-C0.c = N["s"];
-C0.d = s;
-C0.e = N.s;
-C0.f = N["s"];
 // non-widening positions
 // element access
 o[s];
@@ -410,8 +407,11 @@ Math.random() * 2 ? N["s"] : "a";
     [N.s]: "b",
 });
 class C1 {
+    static [s];
+    static [N.s];
+    [s];
+    [N.s];
 }
-N.s, N.s;
 const o3 = {
     method1() {
         return s; // return type should not widen due to contextual type

--- a/tests/baselines/reference/uniqueSymbolsDeclarations.js
+++ b/tests/baselines/reference/uniqueSymbolsDeclarations.js
@@ -283,14 +283,13 @@ async function* asyncGenFuncYieldLetCall() { yield letCall; }
 async function* asyncGenFuncYieldVarCall() { yield varCall; }
 // classes
 class C {
-    constructor() {
-        this.readonlyCall = Symbol();
-        this.readwriteCall = Symbol();
-    }
+    static readonlyStaticCall = Symbol();
+    static readonlyStaticType;
+    static readonlyStaticTypeAndCall = Symbol();
+    static readwriteStaticCall = Symbol();
+    readonlyCall = Symbol();
+    readwriteCall = Symbol();
 }
-C.readonlyStaticCall = Symbol();
-C.readonlyStaticTypeAndCall = Symbol();
-C.readwriteStaticCall = Symbol();
 const constInitToCReadonlyStaticCall = C.readonlyStaticCall;
 const constInitToCReadonlyStaticType = C.readonlyStaticType;
 const constInitToCReadonlyStaticTypeAndCall = C.readonlyStaticTypeAndCall;
@@ -339,26 +338,24 @@ const o2 = {
 };
 // property initializers
 class C0 {
-    constructor() {
-        this.a = s;
-        this.b = N.s;
-        this.c = N["s"];
-        this.d = s;
-        this.e = N.s;
-        this.f = N["s"];
-    }
+    static a = s;
+    static b = N.s;
+    static c = N["s"];
+    static d = s;
+    static e = N.s;
+    static f = N["s"];
+    a = s;
+    b = N.s;
+    c = N["s"];
+    d = s;
+    e = N.s;
+    f = N["s"];
     method1() { return s; }
     async method2() { return s; }
     async *method3() { yield s; }
     *method4() { yield s; }
     method5(p = s) { return p; }
 }
-C0.a = s;
-C0.b = N.s;
-C0.c = N["s"];
-C0.d = s;
-C0.e = N.s;
-C0.f = N["s"];
 // non-widening positions
 // element access
 o[s];
@@ -385,8 +382,11 @@ Math.random() * 2 ? N["s"] : "a";
     [N.s]: "b",
 });
 class C1 {
+    static [s];
+    static [N.s];
+    [s];
+    [N.s];
 }
-N.s, N.s;
 const o4 = {
     method1() {
         return s; // return type should not widen due to contextual type

--- a/tests/baselines/reference/uniqueSymbolsDeclarationsErrors.js
+++ b/tests/baselines/reference/uniqueSymbolsDeclarationsErrors.js
@@ -84,6 +84,8 @@ function funcInferredReturnType(obj) {
 }
 exports.funcInferredReturnType = funcInferredReturnType;
 class ClassWithPrivateNamedProperties {
+    [s];
+    static [s];
 }
 exports.ClassWithPrivateNamedProperties = ClassWithPrivateNamedProperties;
 class ClassWithPrivateNamedMethods {

--- a/tests/baselines/reference/uniqueSymbolsErrors.js
+++ b/tests/baselines/reference/uniqueSymbolsErrors.js
@@ -91,6 +91,8 @@ const shouldNotBeAssignable: string = Symbol();
 // classes
 class InvalidClass {
     constructor(invalidConstructorArgType) { }
+    invalidReadonlyPropertyType;
+    invalidPropertyType;
     invalidArgType(arg) { return; }
     invalidRestArgType(...args) { return; }
     invalidReturnType() { return; }
@@ -100,6 +102,7 @@ class InvalidClass {
     invalidTypeParameterDefault() { return; }
     get invalidGetter() { return; }
     set invalidSetter(arg) { return; }
+    static invalidStaticPropertyType;
     static invalidStaticArgType(arg) { return; }
     static invalidStaticRestArgType(...args) { return; }
     static invalidStaticReturnType() { return; }

--- a/tests/baselines/reference/variableDeclarationDeclarationEmitUniqueSymbolPartialStatement.js
+++ b/tests/baselines/reference/variableDeclarationDeclarationEmitUniqueSymbolPartialStatement.js
@@ -16,8 +16,8 @@ var Foo = /** @class */ (function () {
     }
     return Foo;
 }());
-_a = key;
 exports.Foo = Foo;
+_a = key;
 
 
 //// [variableDeclarationDeclarationEmitUniqueSymbolPartialStatement.d.ts]


### PR DESCRIPTION
The transformation of class fields has been moved to the ESNext transformation on [this branch](/joeywatts/TypeScript/tree/class-properties-esnext).

This PR is for discussion on the baseline changes (so it doesn't crowd the logic of the PR).