### PR TITLE
stanceEsnext private instance fields test case

### DIFF
--- a/tests/baselines/reference/privateNameNestedClassNameConflict.js
+++ b/tests/baselines/reference/privateNameNestedClassNameConflict.js
@@ -1,0 +1,27 @@
+//// [privateNameNestedClassNameConflict.ts]
+class A {
+    #foo: string;
+    constructor () {
+        class A {
+            #foo: string;
+        }
+    }
+}
+
+//// [privateNameNestedClassNameConflict.js]
+var _foo;
+var A = /** @class */ (function () {
+    function A() {
+        _foo.set(this, void 0);
+        var _foo;
+        var A = /** @class */ (function () {
+            function A() {
+                _foo.set(this, void 0);
+            }
+            return A;
+        }());
+        _foo = new WeakMap();
+    }
+    return A;
+}());
+_foo = new WeakMap();

--- a/tests/baselines/reference/privateNameNestedClassNameConflict.symbols
+++ b/tests/baselines/reference/privateNameNestedClassNameConflict.symbols
@@ -1,0 +1,16 @@
+=== tests/cases/conformance/classes/members/privateNames/privateNameNestedClassNameConflict.ts ===
+class A {
+>A : Symbol(A, Decl(privateNameNestedClassNameConflict.ts, 0, 0))
+
+    #foo: string;
+>#foo : Symbol(A[#foo], Decl(privateNameNestedClassNameConflict.ts, 0, 9))
+
+    constructor () {
+        class A {
+>A : Symbol(A, Decl(privateNameNestedClassNameConflict.ts, 2, 20))
+
+            #foo: string;
+>#foo : Symbol(A[#foo], Decl(privateNameNestedClassNameConflict.ts, 3, 17))
+        }
+    }
+}

--- a/tests/baselines/reference/privateNameNestedClassNameConflict.types
+++ b/tests/baselines/reference/privateNameNestedClassNameConflict.types
@@ -1,0 +1,16 @@
+=== tests/cases/conformance/classes/members/privateNames/privateNameNestedClassNameConflict.ts ===
+class A {
+>A : A
+
+    #foo: string;
+>#foo : string
+
+    constructor () {
+        class A {
+>A : A
+
+            #foo: string;
+>#foo : string
+        }
+    }
+}

--- a/tests/cases/conformance/classes/members/privateNames/privateNameNestedClassNameConflict.ts
+++ b/tests/cases/conformance/classes/members/privateNames/privateNameNestedClassNameConflict.ts
@@ -1,0 +1,8 @@
+class A {
+    #foo: string;
+    constructor () {
+        class A {
+            #foo: string;
+        }
+    }
+}


### PR DESCRIPTION
Add test case for the naming conflict that can
happen with generated variable names when downleveling
nested classes with private names.

The esnext-private-instance-fields branch currently produces the
wrong result: name conflict in the emit that will cause a runtime failure.
The bug in the output is here: https://github.com/joeywatts/TypeScript/pull/18/files#diff-bd4b5bbd2e0803b498f14c05f881f296R23

Signed-off-by: Max Heiber <mheiber@bloomberg.net>